### PR TITLE
 Ignore docker tags containing {a, b, rc, p(review)} after version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,6 +24,6 @@
   },
   "rebaseStalePrs": false,
   "schedule": ["after 7:00 before 19:00 every weekday"],
-  "timezone": "Europe/Berlin"
-  "unstablePattern": "[\d.]+[pbarc]+"
+  "timezone": "Europe/Berlin",
+  "unstablePattern": "[\\d.]+[pbarc]+"
 }


### PR DESCRIPTION
https://github.com/PicturePipe/renovate-config/pull/2, this time with valid JSON