### PR TITLE
Explicitly ignore Python 3.8 for now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,10 @@
       {
         "packagePatterns": ["circleci/.+"],
         "recreateClosed": true
+      },
+      {
+        "packageNames": ["circleci/python", "python"],
+        "allowedVersions": "<3.8"
       }
     ]
   },
@@ -24,6 +28,5 @@
   },
   "rebaseStalePrs": false,
   "schedule": ["after 7:00 before 19:00 every weekday"],
-  "timezone": "Europe/Berlin",
-  "unstablePattern": "[\\d.]+[pbarc]+"
+  "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION
Renovate's unstablePattern doesn't work as documented anymore:
https://github.com/renovatebot/renovate/issues/3929

Explicitly limit Python to version 3.7 for now.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
