### PR TITLE
Don't allow upgrades to Traefik 2.0 for now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,8 +10,12 @@
         "recreateClosed": true
       },
       {
-        "packageNames": ["circleci/python", "python"],
-        "allowedVersions": "<3.8"
+        "packagenames": ["circleci/python", "python"],
+        "allowedversions": "<3.8"
+      },
+      {
+        "packagenames": ["traefik"],
+        "allowedversions": "<2.0"
       }
     ]
   },


### PR DESCRIPTION
Traefik 2.0 is still in alpha, so we should not update to it right now.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->

This is related to https://github.com/PicturePipe/onsite-library/pull/227#issuecomment-513736270

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
