### PR TITLE
Define last minor versions for python and traefik Docker images

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,11 +11,11 @@
       },
       {
         "packagenames": ["circleci/python", "python"],
-        "allowedversions": "<3.8"
+        "allowedversions": "<=3.7"
       },
       {
         "packagenames": ["traefik"],
-        "allowedversions": "<2.0"
+        "allowedversions": "<=1.7"
       }
     ]
   },


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->
The current `allowedversions` values do not work: Pull requests have been created to update python to 3.8.0b1 and traefik to 2.0.0-beta1.

Set `allowedversions` to match the last minor version that should be used.

https://github.com/PicturePipe/infrastructure/pull/122

https://github.com/PicturePipe/onsite-library/pull/231

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
