### PR TITLE
Configure Python Docker images to use PEP440 versioning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       },
       {
         "packagenames": ["circleci/python", "python"],
-        "allowedVersions": "<=3.7"
+        "versionScheme": "pep440"
       },
       {
         "packagenames": ["traefik"],


### PR DESCRIPTION
As suggested here https://github.com/renovatebot/config-help/issues/307#issuecomment-514185895
by rarkins, we should be able to configure which versioning scheme is
used by Python, so that the 3.8.0b versions will be considered unstable
and not elegible for an upgrade.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
