### PR TITLE
Limit Python versions to 3.7

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
       },
       {
         "packageNames": ["circleci/python", "python"],
-        "versionScheme": "pep440"
+        "allowedVersions": "<=3.7"
       },
       {
         "packageNames": ["traefik"],


### PR DESCRIPTION
After testing in separate repository, it turns out that if the
configuration is done right, it actually works.

https://github.com/cfra/python-update-test/blob/master/renovate.json

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [X] I’ve tested this in a standalone repository.
