### PR TITLE
Enable automerge for digests and pin them

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,7 +19,11 @@
       }
     ]
   },
-  "extends": ["config:base", "docker:enableMajor"],
+  "extends": [
+    "config:base",
+    "default:automergeDigest",
+    "docker:enableMajor"
+  ],
   "labels": ["renovate"],
   "packageRules": [
     {
@@ -27,6 +31,7 @@
       "depTypeList": ["devDependencies"]
     }
   ],
+  "pinDigests": true,
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },


### PR DESCRIPTION
We rarely check the diff of Docker images if only their digest changes.
Therefore, let's merge them automatically if all tests pass.

Also, ensure all references to Docker images are completely specified,
including a digest.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
