### PR TITLE
Enable automerge for pinned Docker image versions

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,10 @@
         "packageNames": ["traefik"],
         "allowedVersions": "<=1.7"
       }
-    ]
+    ],
+    "pin": {
+      "automerge": true
+    }
   },
   "extends": [
     "config:base",


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->
Docker image versions should be pinned, so that environments are
reproducible.

Therefore pull requests pinning a Docker version should be merged
automatically if no tests fail.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
