### PR TITLE
Add prHourlyLimit and set to 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -38,6 +38,7 @@
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },
+  "prHourlyLimit": 3,
   "rebaseStalePrs": false,
   "schedule": ["after 7:00 before 19:00 every weekday"],
   "timezone": "Europe/Berlin"


### PR DESCRIPTION
Currently there are situations where Renovate creates many pull requests
at once, e.g. at the beginning of a working day.

Three pull requests per hour should be an amount we should be able to
merge without a huge delay.

https://docs.renovatebot.com/configuration-options/#prhourlylimit

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
