### PR TITLE
Revert "renovate: Disable stale pull request rebasing"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,7 +39,6 @@
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },
   "prHourlyLimit": 3,
-  "rebaseStalePrs": false,
   "schedule": ["after 8:00 before 20:00 every weekday"],
   "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION
With `rebaseStalePrs` set to `false` updates of Docker, JavaScript or
Python dependencies are not rebased after other pull requests have been
merged.

Example:

1. Renovate opens a pull request to update a Python dependency, build
   status is green.
2. Renovate opens a pull request to update the Python Docker image,
   build status is green.
3. The pull request to update the Python dependency is merged.
4. The pull request to update the Python Docker image is not rebased.
5. The pull request to update the Python Docker image is merged.
6. Mainline build status is now red because the update of the Python
   dependency does not work with the updated Python Docker image.

If the pull request to update the Python Docker image would have been
rebased, the problem with the Python dependency would have been
identified in advance.

This reverts commit 9a4977bf32de39d273599ac54b4737d11ffe00ef.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
