### PR TITLE
Remove option to automerge JavaScript devDependencies

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,12 +29,6 @@
     "docker:enableMajor"
   ],
   "labels": ["renovate"],
-  "packageRules": [
-    {
-      "automerge": true,
-      "depTypeList": ["devDependencies"]
-    }
-  ],
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },


### PR DESCRIPTION
Updates of devDependencies usually contain changes that should be
reviewed. Just a green build is not enough.

A manual review is especially important to see if a dependency has a new
feature we want to use.

The change is also necessary because we'll soon start to use
[renovate-approve-bot](https://github.com/renovatebot/renovate-approve-bot)
which would otherwise merge all devDependencies updates.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
