### PR TITLE
Restrict CircleCI digest updates to early Mondays

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,6 +16,11 @@
       {
         "packageNames": ["traefik"],
         "allowedVersions": "<=1.7"
+      },
+      {
+        "extends": ["schedule:weekly"],
+        "packageNames": ["circleci/.+"],
+        "updateTypes": ["digest"]
       }
     ],
     "pinDigests": true,


### PR DESCRIPTION
Digests of CircleCI Docker images are updated every day. This creates a
lot of "noise", even if the pull requests are merged by a bot.

Restrict CircleCI digest updates to early Mondays in order for pull
requests to be created only once a week.

https://docs.renovatebot.com/configuration-options/#schedule

https://docs.renovatebot.com/presets-schedule/

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
