### PR TITLE
Postpone CircleCI digest updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,8 +18,8 @@
         "packageNames": ["traefik"]
       },
       {
-        "extends": ["schedule:weekly"],
         "packagePatterns": ["circleci/.+"],
+        "schedule": ["after 4:00 before 8:00 on Monday"],
         "updateTypes": ["digest"]
       }
     ],


### PR DESCRIPTION
The schedule config preset "schedule:weekly" uses a schedule set to
"before 3am on Monday". CircleCI updates the digest after 2:00. So
Renovate creates two pull requests Monday night. The first after
midnight and the second after 2:00.

Set the schedule to "after after 4:00 before 8:00 on Monday". This
should produce only a single pull request per week per digest update.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
