### PR TITLE
Update allowedVersions for Node.js to ignore v13

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,7 @@
   "docker": {
     "packageRules": [
       {
-        "allowedVersions": "<11 || >11",
+        "allowedVersions": "<13 || >13",
         "packageNames": ["circleci/node", "node"]
       },
       {


### PR DESCRIPTION
The initial release of Node.js v13 was on 2019-10-22. This is not a LTS
release, so Renovate should not propose any updates for it.

https://nodejs.org/en/about/releases/

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
