### PR TITLE
Update allowedVersions for Python from 3.7 to 3.8

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
         "recreateClosed": true
       },
       {
-        "allowedVersions": "<=3.7",
+        "allowedVersions": "<=3.8",
         "packageNames": ["circleci/python", "python"]
       },
       {


### PR DESCRIPTION
Python 3.8 has been released on 2019-10-14 and is available on Heroku.

https://www.python.org/downloads/release/python-380/

https://devcenter.heroku.com/articles/python-support#supported-runtimes

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
