### PR TITLE
Update schedules to do updates by night

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,7 @@
       },
       {
         "packagePatterns": ["circleci/.+"],
-        "schedule": ["after 4:00 before 8:00 on Monday"],
+        "schedule": ["on Monday after 22:00 before 6:00"],
         "updateTypes": ["digest"]
       }
     ],
@@ -41,7 +41,6 @@
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },
-  "prHourlyLimit": 3,
-  "schedule": ["after 8:00 before 20:00 every weekday"],
+  "schedule": ["every weekday after 22:00 before 6:00"],
   "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION
Reduce distraction during working hours by doing updates by night.

Remove prHourlyLimit, restriction makes no sense by night.

Improve readability by using a grammar where days come before times.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
