### PR TITLE
Revert "Revert "renovate: Disable stale pull request rebasing""

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,7 @@
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },
+  "rebaseStalePrs": false,
   "schedule": ["every weekday after 22:00 before 6:00"],
   "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION
This reverts commit 26bd06def028dacdfefd1aa0e65bc1d0d2a99cce.

Rebasing all pull requests of renovate automatically leads to annoying
spam in Slack.

It also wastes tons of energy since CI is run without anybody caring
about it.

It should be turned off.

To avoid the problem described in the revert, I suggest two possible
approaches to a solution:

a) think before merging an update
b) enable the "Require pull requests to be up-to-date" check

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
