### PR TITLE
Fix Renovate schedules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,7 +23,10 @@
       },
       {
         "packagePatterns": ["circleci/.+"],
-        "schedule": ["on Monday after 22:00 before 6:00"],
+        "schedule": [
+          "on Monday after 22:00",
+          "on Monday before 6:00"
+        ],
         "updateTypes": ["digest"]
       }
     ],
@@ -42,6 +45,9 @@
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },
   "rebaseStalePrs": false,
-  "schedule": ["every weekday after 22:00 before 6:00"],
+  "schedule": [
+    "every weekday after 22:00",
+    "every weekday before 6:00"
+  ],
   "timezone": "Europe/Berlin"
 }


### PR DESCRIPTION
The new schedules introduced in ad77669 never evaluate to true because
the current time is either lower or bigger than one of the two times.

Split the schedules into two objects, one for before midnight and one
after.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
