### PR TITLE
Update Docker digest schedule to run only Monday morning

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,10 +23,7 @@
       },
       {
         "packagePatterns": ["circleci/.+"],
-        "schedule": [
-          "on Monday after 22:00",
-          "on Monday before 6:00"
-        ],
+        "schedule": ["on Monday before 6:00"],
         "updateTypes": ["digest"]
       }
     ],


### PR DESCRIPTION
The current schedule will also create updates on Mondays after 22:00.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
