### PR TITLE
Add JSON validation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,15 @@ commands:
           name: Validate << parameters.config-file >>
 
 jobs:
-  validate:
+  validate-json:
+    docker:
+      - image: circleci/buildpack-deps:stable-scm@sha256:f5c561e7c4b27d8085b2e423180e2ad17d62fa419f87e26482102c14957ecde8
+    steps:
+      - checkout
+      - run:
+          command: make validate-json
+          name: Validate JSON files
+  validate-presets:
     docker:
       - image: renovate/renovate:19.66.15-slim@sha256:f3e9888652060a11f42c32b03f272bfd462877b4164e682e86ca2f87d85ea9d0
     steps:
@@ -35,4 +43,7 @@ workflows:
   version: 2
   validate:
     jobs:
-      - validate
+      - validate-json
+      - validate-presets:
+          requires:
+            - validate-json

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@
 help:
 	@grep -E '^[\.a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
-.PHONY: validate
-validate: ## Validate Renovate config presets
+.PHONY: validate-json
+validate-json: ## Validate JSON files
+	find . -name '*.json' -print0 | xargs -0 -I % -n1 sh  -c 'echo %; jq . % > /dev/null;'
+
+.PHONY: validate-presets
+validate-presets: ## Validate Renovate config presets
 	docker-compose run --rm validate
 	docker-compose run -e RENOVATE_CONFIG_FILE=/var/src/renovate-config/circleci-orb.json --rm \
 		validate
@@ -13,3 +17,6 @@ validate: ## Validate Renovate config presets
 		validate
 	docker-compose run -e RENOVATE_CONFIG_FILE=/var/src/renovate-config/onsite-library.json --rm \
 		validate
+
+.PHONY: validate
+validate: validate-json validate-presets ## Validate JSON files and Renovate config presets


### PR DESCRIPTION
<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->
Renovate's validation script checks keywords, but not the JSON structure
in general.

Add a `validate-json` target to validate if all JSON files can be parsed
as JSON.

<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [x] I’ve added tests to confirm my change works
