### PR TITLE
Add pep440 versionScheme to Python Docker images

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,7 +11,8 @@
       },
       {
         "allowedVersions": "<=3.8",
-        "packageNames": ["circleci/python", "python"]
+        "packageNames": ["circleci/python", "python"],
+        "versionScheme": "pep440"
       },
       {
         "packagePatterns": ["circleci/.+"],

--- a/legacy.json
+++ b/legacy.json
@@ -2,8 +2,9 @@
   "docker": {
     "packageRules": [
       {
+        "allowedVersions": "<3",
         "packageNames": ["circleci/python", "python"],
-        "allowedVersions": "<3"
+        "versionScheme": "pep440"
       },
       {
         "packageNames": ["memcached"],


### PR DESCRIPTION
> Renovate defaults to assuming suffixes indicate compatibility so will
> never change it.

With Renovate's default behavior Python Docker image versions will not
always be updated when necessary.

https://docs.renovatebot.com/docker/#version-compatibility

https://github.com/renovatebot/renovate/issues/4827

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
