### PR TITLE
Use regex to configure Python Docker versionScheme

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,7 +12,7 @@
       {
         "allowedVersions": "<=3.8",
         "packageNames": ["circleci/python", "python"],
-        "versionScheme": "pep440"
+        "versionScheme": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>(a|b|rc)\\d+)?(-(?<compatibility>.*))?$"
       },
       {
         "packagePatterns": ["circleci/.+"],

--- a/legacy.json
+++ b/legacy.json
@@ -4,7 +4,7 @@
       {
         "allowedVersions": "<3",
         "packageNames": ["circleci/python", "python"],
-        "versionScheme": "pep440"
+        "versionScheme": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>(a|b|rc)\\d+)?(-(?<compatibility>.*))?$"
       },
       {
         "packageNames": ["memcached"],


### PR DESCRIPTION
68ea986193f1f4c08660e731e55e7a7d86532255 configured the versionScheme to
use the pep440 implementation.

But pep440 doesn't support "compatibility" values and works only with an
operator like `==`.

Add a regex for the Python Docker images versionScheme. The regex
follows the Python versioning practice and provides all capture groups
supported by Renovate.

https://github.com/PicturePipe/renovate-config/pull/153#issuecomment-571116485

https://github.com/renovatebot/renovate/issues/4827#issuecomment-569368866

https://docs.renovatebot.com/configuration-options/#versionscheme

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
