### PR TITLE
Tighten schedule for CircleCI Docker digest updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,7 @@
       },
       {
         "packagePatterns": ["circleci/.+"],
-        "schedule": ["on Monday before 6:00"],
+        "schedule": ["on Monday after 3:00 before 6:00"],
         "updateTypes": ["digest"]
       }
     ],


### PR DESCRIPTION
CircleCI Docker images are automatically build every night at 00:00 UTC.
This translates to 01:00 CET or 02:00 CEST, depending on the date.

As a result Renovate creates two pull requests. A first one with the
digest before the nightly build and another after it.

Configure digest schedule to run only between 03:00 and 06:00 CET/CEST.

https://github.com/circleci/circleci-images/blob/master/.circleci/config.yml#L428

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
