### PR TITLE
Update Renovate schema download location

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
           paths:
             - ~/.npm
       - run:
-          command: curl https://raw.githubusercontent.com/renovatebot/renovate/master/renovate-schema.json > renovate-schema.json
+          command: curl -fsSL https://docs.renovatebot.com/renovate-schema.json > renovate-schema.json
           name: Fetch renovate configuration schema
       - validate-preset:
          config-file: /home/ubuntu/project/circleci-orb.json

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ clean: ## Clean up previous state to perform full re-validation
 	rm -f .validated-*.json
 
 renovate-schema.json:
-	curl https://raw.githubusercontent.com/renovatebot/renovate/master/renovate-schema.json > "$@"
+	curl -fsSL https://docs.renovatebot.com/renovate-schema.json > "$@"
 
 .validated-%.json: %.json renovate-schema.json
 	docker-compose run \


### PR DESCRIPTION
In https://github.com/renovatebot/renovate/pull/5420 renovate removed its schema from source control and started to publish it as part of the documentation instead.

Update the download location accordingly and add flags to curl invocation so that curl will not fail silently on future location changes.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
