### PR TITLE
Disable semantic commit messages

### DIFF
--- a/default.json
+++ b/default.json
@@ -28,6 +28,7 @@
   "extends": [
     "config:base",
     "default:automergeDigest",
+    "default:semanticCommitsDisabled",
     "docker:enableMajor"
   ],
   "labels": ["renovate"],


### PR DESCRIPTION
Renovate autodetects whether to use semantic commit messages or not.

As can be seen here https://github.com/PicturePipe/hatch/pull/679 that
autodetection result is not stable and leads to lots of ripple due to
renames.

We are not using semantic commit messages, so disable them specifically.

https://docs.renovatebot.com/semantic-commits/

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
