### PR TITLE
Add labels for datasources and security updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -12,8 +12,8 @@
       "packageNames": ["circleci/node", "node"]
     },
     {
-      "packagePatterns": ["circleci/.+"],
       "datasources": ["docker"],
+      "packagePatterns": ["circleci/.+"],
       "recreateClosed": true
     },
     {
@@ -23,16 +23,37 @@
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>(a|b|rc)\\d+)?(-(?<compatibility>.*))?$"
     },
     {
-      "packagePatterns": ["circleci/.+"],
       "datasources": ["docker"],
+      "packagePatterns": ["circleci/.+"],
       "schedule": ["on Monday after 3:00 before 6:00"],
       "updateTypes": ["digest"]
     },
     {
       "datasources": ["docker"],
+      "labels": ["renovate", "docker-update"],
       "pin": {
         "automerge": true
       }
+    },
+    {
+      "datasources": ["npm"],
+      "labels": ["renovate", "npm-update"]
+    },
+    {
+      "datasources": ["orb"],
+      "labels": ["renovate", "orb-update"]
+    },
+    {
+      "datasources": ["pypi"],
+      "labels": ["renovate", "pypi-update"]
+    },
+    {
+      "datasources": ["terraform-module", "terraform-provider"],
+      "labels": ["renovate", "terraform-update"]
+    },
+    {
+      "labels": ["renovate", "update-major"],
+      "updateTypes": ["major"]
     }
   ],
   "pinDigests": true,
@@ -44,5 +65,8 @@
     "every weekday after 22:00",
     "every weekday before 6:00"
   ],
-  "timezone": "Europe/Berlin"
+  "timezone": "Europe/Berlin",
+  "vulnerabilityAlerts": {
+    "labels": ["renovate", "security"]
+  }
 }


### PR DESCRIPTION
These labels will it make easier to identify or filter pull requests
created by Renovate by it's type.

https://docs.renovatebot.com/configuration-options/#labels

https://docs.renovatebot.com/configuration-options/#datasources

https://docs.renovatebot.com/configuration-options/#updatetypes

https://docs.renovatebot.com/configuration-options/#vulnerabilityalerts

https://docs.renovatebot.com/modules/datasource/

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [x] I’ve added tests to confirm my change works
