### PR TITLE
Enable npmDedupe post update option

### DIFF
--- a/default.json
+++ b/default.json
@@ -5,6 +5,10 @@
     "default:semanticCommitsDisabled",
     "docker:enableMajor"
   ],
+  "labels": ["renovate"],
+  "npm": {
+    "postUpdateOptions": ["npmDedupe"]
+  },
   "packageRules": [
     {
       "allowedVersions": "<13 || >13",
@@ -57,7 +61,6 @@
     }
   ],
   "pinDigests": true,
-  "labels": ["renovate"],
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },


### PR DESCRIPTION
At the moment `npm dedupe` must be run manually.

With this new option Renovate will run the command every time a package
has been updated.

https://docs.renovatebot.com/configuration-options/#postupdateoptions

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
