### PR TITLE
Ignore Nginx mainline updates

### DIFF
--- a/default.json
+++ b/default.json
@@ -11,6 +11,11 @@
   },
   "packageRules": [
     {
+      "allowedVersions": "<1.19 || >1.19",
+      "datasources": ["docker"],
+      "packageNames": ["nginx"]
+    },
+    {
       "allowedVersions": "<13 || >13",
       "datasources": ["docker"],
       "packageNames": ["circleci/node", "node"]


### PR DESCRIPTION
The current Nginx stable branch is 1.18, the next will be 1.20. All
projects using Nginx should stay on the stable branch to reduce the
number of updates and new features.

Ignore any updates to Nginx 1.19, which is the current mainline branch.

https://www.nginx.com/blog/nginx-1-18-1-19-released/

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
