### PR TITLE
Quench ajv warnings related to $ref

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ commands:
             RENOVATE_CONFIG_FILE: << parameters.config-file >>
           name: Validate << parameters.config-file >>
       - run:
-          command: npx ajv -s renovate-schema.json -d << parameters.config-file >>
+          command: npx ajv --extend-refs=true -s renovate-schema.json -d << parameters.config-file >>
           name: Validate << parameters.config-file >> against JSON schema
 
 jobs:

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ renovate-schema.json:
 		-e "RENOVATE_CONFIG_FILE=/var/src/renovate-config/$<" \
 		--rm \
 		validate
-	npx ajv -s renovate-schema.json -d "$<"
+	npx ajv --extend-refs=true -s renovate-schema.json -d "$<"
 	touch "$@"
 
 .PHONY: validate


### PR DESCRIPTION
Renovate uses `"$ref": "#"` in many places of its schema to indicate
that everything which is permissible as top level config is also
valid in a subtree.

According to https://tools.ietf.org/id/draft-pbryan-zyp-json-ref-03.html#rfc.section.3
(apparently this feature never made it past draft stage but is still
in active use) every keyword except `"$ref"` should be ignored when
this feature is used.

However, Renovate intentionally specifies keywords in addition to "$ref".

While this might not be a standard conformant schema, we can validate it
as intended by Renovate by setting `extendRefs` to `true` and not
ignoring those keywords.

As the Renovate schema is autogenerated, and as the option only takes
more validation options into account, there seems little risk associated
with enabling it.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
