### PR TITLE
Fix renovate automerge datasource

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "packageRules": [
     {
       "automerge": true,
-      "datasources": ["js"],
+      "datasources": ["npm"],
       "packageNames": ["renovate"]
     }
   ]


### PR DESCRIPTION
There is no datasource named `js`.

Correct datasource name is `npm`.

https://docs.renovatebot.com/modules/datasource/#npm-datasource

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
