### PR TITLE
Deactivate Node.js Docker image updates to "Current" version

### DIFF
--- a/default.json
+++ b/default.json
@@ -16,7 +16,7 @@
       "packageNames": ["nginx"]
     },
     {
-      "allowedVersions": "<13 || >13",
+      "allowedVersions": "<=12",
       "datasources": ["docker"],
       "packageNames": ["circleci/node", "node"]
     },


### PR DESCRIPTION
Instead of having ongoing pull requests to update the Node.js Docker
image to the "Current" version we should actively decide when we want to
update to the next stable version.

This behavior matches Renovate's default configuration of the
`supportPolicy` option. Renovate will only update to "Current" once it
has been promoted to LTS.

https://docs.renovatebot.com/node/#configuring-support-policy

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
