### PR TITLE
Add poetry preset

### DIFF
--- a/poetry.json
+++ b/poetry.json
@@ -1,0 +1,6 @@
+{
+  "extends": ["github>PicturePipe/renovate-config"],
+  "pip_requirements": {
+    "enabled": false
+  }
+}

--- a/scripts/validate.sh
+++ b/scripts/validate.sh
@@ -12,7 +12,7 @@ set -o pipefail
 # Turn on traces, useful while debugging but commented out by default
 # set -o xtrace
 
-readonly PRESETS=(circleci-orb.json default.json legacy.json onsite-library.json)
+readonly PRESETS=(circleci-orb.json default.json legacy.json onsite-library.json poetry.json)
 readonly SCHEMA_URL=https://docs.renovatebot.com/renovate-schema.json
 
 echo "Downloading $SCHEMA_URL"


### PR DESCRIPTION
We export our Poetry requirements as `requirements.txt` for deployments
to Heroku.

We don't want Renovate to upgrade the `requirements.txt` file in those
cases, as it should always follow the contents of our Poetry
requirements.

Create a preset that is the standard preset, but with the
`pip_requirements` manager disabled.

<!-- Please provide a brief summary of your changes. -->
<!-- Link to an open issue for more information (if applicable). -->
<!-- How to link to issues: https://help.github.com/en/articles/autolinked-references-and-urls -->
<!-- How to create task lists with clickable checkboxes: -->
<!-- https://help.github.com/en/articles/about-task-lists -->


<!-- Please ensure you’ve done all of these things (if applicable). -->
<!-- You can replace the `[ ]` with `[x]` to mark each task as done. -->
- [ ] I’ve added tests to confirm my change works
