### PR TITLE
Add reviewers and schedule to vulnerabilityAlerts

### DIFF
--- a/default.json
+++ b/default.json
@@ -75,6 +75,8 @@
   ],
   "timezone": "Europe/Berlin",
   "vulnerabilityAlerts": {
-    "labels": ["renovate", "security"]
+    "labels": ["renovate", "security"],
+    "reviewers": ["team:@PicturePipe/software-development"],
+    "schedule": ["at any time"]
   }
 }


### PR DESCRIPTION
Currently vulnerability updates follow the default schedule, which means
they are created during non-working hours. This increases the time
unnecessarily until a vulnerability update gets reviewed and deployed.

Add a schedule to `vulnerabilityAlerts` which allows updates "at any
time".

Furthermore add `reviewers` and assign the review to
`@PicturePipe/software-development` in order for the team members to be
notified immediately.

https://docs.renovatebot.com/configuration-options/#reviewers

https://docs.renovatebot.com/configuration-options/#schedule
