### PR TITLE
Remove extends key from poetry preset

### DIFF
--- a/poetry.json
+++ b/poetry.json
@@ -1,5 +1,4 @@
 {
-  "extends": ["github>PicturePipe/renovate-config"],
   "pip_requirements": {
     "enabled": false
   }


### PR DESCRIPTION
All existing presets have been designed in a way that they don't extend
any other preset inside this repository. This way every preset must be
added explicitly to avoid any surprises, as explained in `README.md`.

The poetry preset extends the default preset, which opposes this idea.
