### PR TITLE
Replace pinDigests key with docker:pinDigests preset

### DIFF
--- a/default.json
+++ b/default.json
@@ -4,7 +4,8 @@
     "config:base",
     "default:automergeDigest",
     "default:semanticCommitsDisabled",
-    "docker:enableMajor"
+    "docker:enableMajor",
+    "docker:pinDigests"
   ],
   "labels": ["renovate"],
   "npm": {
@@ -66,7 +67,6 @@
       "updateTypes": ["major"]
     }
   ],
-  "pinDigests": true,
   "pip_requirements": {
     "fileMatch": ["(^|/)requirements(\/*[\\w-]*).(txt|pip)$"]
   },


### PR DESCRIPTION
Repositories using our Renovate presets get no Node.js updates for the
`volta` field in package.json.

Detection of the Node.js version fails with this error:

> Error getting tag commit from GitHub repo

Use the `docker:pinDigests` preset instead of `pinDigests` as a
top-level key to solve the problem.

https://docs.renovatebot.com/presets-docker/#dockerpindigests
