### PR TITLE
Extend packageRules for CircleCI convenience Docker images

### DIFF
--- a/default.json
+++ b/default.json
@@ -20,22 +20,22 @@
     {
       "allowedVersions": "<=12",
       "datasources": ["docker"],
-      "packageNames": ["circleci/node", "node"]
+      "packageNames": ["cimg/node", "circleci/node", "node"]
     },
     {
       "datasources": ["docker"],
-      "packagePatterns": ["circleci/.+"],
+      "packagePatterns": ["cimg/.+", "circleci/.+"],
       "recreateClosed": true
     },
     {
       "allowedVersions": "<=3.8",
       "datasources": ["docker"],
-      "packageNames": ["circleci/python", "python"],
+      "packageNames": ["cimg/python", "circleci/python", "python"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>(a|b|rc)\\d+)?(-(?<compatibility>.*))?$"
     },
     {
       "datasources": ["docker"],
-      "packagePatterns": ["circleci/.+"],
+      "packagePatterns": ["cimg/.+", "circleci/.+"],
       "schedule": ["on Monday after 3:00 before 6:00"],
       "updateTypes": ["digest"]
     },

--- a/legacy.json
+++ b/legacy.json
@@ -4,7 +4,7 @@
     {
       "allowedVersions": "<3",
       "datasources": ["docker"],
-      "packageNames": ["circleci/python", "python"],
+      "packageNames": ["cimg/python", "circleci/python", "python"],
       "versioning": "regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)(?<prerelease>(a|b|rc)\\d+)?(-(?<compatibility>.*))?$"
     },
     {


### PR DESCRIPTION
We started using CircleCI convenience Docker images, so the same
`packageRules` as for legacy images should be applied.

https://circleci.com/docs/2.0/circleci-images/
